### PR TITLE
check auth in create filter

### DIFF
--- a/pages/filters/create.vue
+++ b/pages/filters/create.vue
@@ -275,7 +275,6 @@ async function filterToCreate(): Promise<ListingListener | null> {
   return filterToCreate
 }
 
-
 async function handleFilters(): Promise<{ name: string, value: any }[]> {
   const rawFilter = toRaw(filter.value)
   const filters: { name: string, value: any }[] = []
@@ -337,6 +336,7 @@ async function connectPushNotifications(): Promise<string> {
 }
 
 onMounted(async () => {
+  await useUserStore().checkAuth(useFirebaseAuth()!)
   await Promise.allSettled([filterStore.loadFilters()])
   loadEditParam()
 })


### PR DESCRIPTION
I had check auth (which would create the anonymous account if there isn't one already) only in overview and auctions page before since they would first land there, but since when you first start using the app you get sent to the create page where there was no auth check 